### PR TITLE
出品商品の表示とダミーの表示設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :update, :edit, :destroy]
 
-  def index
-    # @items = Item.order("created_at DESC")
-  end
-
   def new
     @item = Item.new
   end
@@ -17,6 +13,11 @@ class ItemsController < ApplicationController
       render :new
     end
   end
+
+  def index
+    @items = Item.all.order("created_at DESC")
+  end
+
 
   def show
     @item = Item.find(params[:id])

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,24 +127,25 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,12 +154,11 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <% if @item != nil %>
-        <%= @item.image.all %>
       <%# 商品がない場合のダミー %>
+      <% if @items.length == 0 %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>


### PR DESCRIPTION
#what
商品一覧表示機能実装

#why
出品した商品の表示と、商品がない時のダミーの表示設定

ログインしていないユーザーへの商品一覧表示
https://gyazo.com/10f6f527f603394428514dc22ca41abc

商品がない時はダミーが表示される
https://gyazo.com/7310d92090c40417d990ce3f536a7050