### PR TITLE
商品情報編集機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :update, :edit, :destroy]
+  before_action :item_id, only: [:edit, :show, :update]
 
   def new
     @item = Item.new
@@ -20,23 +21,20 @@ class ItemsController < ApplicationController
 
 
   def show
-    @item = Item.find(params[:id])
+    item_id
   end
 
   def edit
-    @item = Item.find(params[:id])
+    item_id
     unless current_user.id == @item.user_id
       redirect_to root_path
     end
   end
 
   def update
-    item = Item.find(params[:id])
-    if item.update(item_new_params)
+    item_id
+    if @item.update(item_new_params)
       redirect_to item_path
-    else
-      @item = Item.find(params[:id])
-      render :edit
     end
   end
 
@@ -49,5 +47,9 @@ class ItemsController < ApplicationController
 
   def item_new_params
     params.require(:item).permit(:name, :image, :explanation, :category_id, :condition_id, :prefecture_id, :shipment_term_id, :price, :shipment_fee_id).merge(user_id: current_user.id)
+  end
+
+  def item_id
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,24 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  
+  def edit
+    @item = Item.find(params[:id])
+    unless current_user.id == @item.user_id
+      redirect_to root_path
+    end
+  end
+
+  def update
+    item = Item.find(params[:id])
+    if item.update(item_new_params)
+      redirect_to item_path
+    else
+      @item = Item.find(params[:id])
+      render :edit
+    end
+  end
+
+
   private
 
   def item_image_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,6 +32,8 @@ class ItemsController < ApplicationController
   def update
     if @item.update(item_new_params)
       redirect_to item_path
+    else
+      render :edit
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,18 +21,15 @@ class ItemsController < ApplicationController
 
 
   def show
-    item_id
   end
 
   def edit
-    item_id
     unless current_user.id == @item.user_id
       redirect_to root_path
     end
   end
 
   def update
-    item_id
     if @item.update(item_new_params)
       redirect_to item_path
     end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model:@item, url:"#", local: true do |f| %>
+    <%= form_with model:@item, url:item_path, local: true do |f| %>
 
     <%# エラー発生時のメッセージが表示 %>
     <%= render 'shared/error_messages',locals: { message:@message }, model: f.object %>
@@ -139,8 +139,8 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "変更する", class:"sell-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>


### PR DESCRIPTION
#what
商品情報編集機能実装
#why
ログインの有無、出品者かどうかで編集権限を分けるため


以下、動作確認動画です。確認お願いします。

商品情報（商品画像・商品名・商品の状態など）を変更できること
https://gyazo.com/efa04a3ea4a00ecf83443f7a347f7141

- 何も編集せずに更新をしても画像無しの商品にならないこと
- 商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
https://gyazo.com/afcbfb54f2252a22f727617e64847728

- ログイン状態の出品者だけが商品情報編集ページに遷移できること
https://gyazo.com/f25b96d43b407d3a7e8584b43cd45708

- ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
https://gyazo.com/62b6056e1437c28299a63d83fc06c0d3

- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること
https://gyazo.com/42cdfa63498d2ff5a3c2f760ed124e25